### PR TITLE
Fix microtype conflict

### DIFF
--- a/README.ctan
+++ b/README.ctan
@@ -11,6 +11,7 @@ Unicode, such as XeTeX or LuaTeX.
 Changelog
 ---------
 
+v0.2.2  2017.02.05 - delay activating text underscore to avoid conflict with microtype package
 v0.2.1  2016.12.18 - gloss file included in CTAN package
 v0.2    2016.10.23 - new macrocommands and docs
 v0.1    2016.05.10 - first draft release

--- a/churchslavonic.sty
+++ b/churchslavonic.sty
@@ -1,6 +1,6 @@
 % Copyright 2016 Slavonic Computing Initiative
 % http://sci.ponomar.net
-% 
+%
 \ProvidesPackage{churchslavonic}[2016/04/19 v0.2 Typesetting in Church Slavonic]
 
 \DeclareOption*{
@@ -15,10 +15,13 @@
 
 % underscore is a valid character in Church Slavonic
 \let\cu@oldunderscore=_
+{%
 \catcode`\_\active
-\protected\def_{\ifmmode\cu@oldunderscore\else\textunderscore\discretionary{}{}{}\fi}
+\global\protected\def_{\ifmmode\cu@oldunderscore\else\textunderscore\discretionary{}{}{}\fi}%
+}%
+\AtBeginDocument{\catcode`\_\active}%
 
-% suppress variable distance between lines 
+% suppress variable distance between lines
 \lineskiplimit -1ex
 
 % margin marks

--- a/churchslavonic.sty
+++ b/churchslavonic.sty
@@ -1,7 +1,7 @@
 % Copyright 2016 Slavonic Computing Initiative
 % http://sci.ponomar.net
 %
-\ProvidesPackage{churchslavonic}[2016/04/19 v0.2 Typesetting in Church Slavonic]
+\ProvidesPackage{churchslavonic}[2017/02/05 v0.2.2 Typesetting in Church Slavonic]
 
 \DeclareOption*{
 	\PassOptionsToPackage{\CurrentOption}{cu-kinovar}


### PR DESCRIPTION
This addresses issue #47 by delaying making underscore an active character until after `\begin{document}`