### PR TITLE
fixed date template containing underscore

### DIFF
--- a/churchslavonic.tex
+++ b/churchslavonic.tex
@@ -14,7 +14,7 @@
 %
 \cuDefineDateFormat{long}{%
   \cuDayName{\cuDOW},
-  \cuNum{\cuDAY}_гѡ~%
+  \cuNum{\cuDAY}\textunderscore гѡ~%
   \cuMonthName{\cuMONTH},~%
   лѣ́та ѿ сотворе́нїѧ мі́ра~\cuNum{\cuYEARAM}%
 }
@@ -111,7 +111,7 @@ declarations into the document preamble:
 
 \begin{verbatim}
 \usepackage{polyglossia}
-\setmainlanguage{churchslavonic} 
+\setmainlanguage{churchslavonic}
 \usepackage{churchslavonic}
 \end{verbatim}
 
@@ -208,12 +208,12 @@ character: \texttt{HyphenChar="005F}, or by declaring all fonts before loading \
 \end{EN}
 
 \begin{RU}
-\cuKinovar{Внимание:} если у вас установлена старая версия пакета \pkg{fontspec}, 
+\cuKinovar{Внимание:} если у вас установлена старая версия пакета \pkg{fontspec},
 переопределенный знак подчеркивания нельзя использовать при задании имен и параметров шрифтов в командах \pkg{fontspec} типа
 \cs{setXXXfont} и \cs{newfontfamily}.
 
 Обычно для церковнославянских шрифтов требуется установить подчеркивание как символ переноса, указав параметр:
-\texttt{HyphenChar=_}. Старые версии \pkg{fontspec} выдадут ошибку. 
+\texttt{HyphenChar=_}. Старые версии \pkg{fontspec} выдадут ошибку.
 Эта проблема присутствует в \TeX\ \texttt{Live 2013} и в \pkg{fontspec v2.3c}.
 
 Мы рекомендуем обновить систему \TeX\ до \TeX\ \texttt{Live 2015} или свежее.
@@ -237,7 +237,7 @@ For more information on the implementation, consult the appropriate section of \
 \section{Числа}
 Способ записи чисел в церковнославянском языке (кириллическая цифирь)
 основывается на древнегреческом и в
-качестве цифр использует буквы. 
+качестве цифр использует буквы.
 За подробностями отсылаем интересующегося читателя к
 соответствующей главе \cite{UN41}.
 \end{RU}
@@ -332,7 +332,7 @@ This makes a difference only if your format is using symbolic names \cs{cuDOW} a
 невозможными датами, например 32 апреля --- такая дата будет отформатирована как 32 апреля. Так что команду \cs{cuDate} можно
 использовать для набора фраз вроде ``дата \verb+\cuDate{2016-04-32}+ не существует ни в одном календаре''.
 
-Однако, если вы используете свой формат даты и в этом формате задействованы символические переменные \cs{cuDOW} (день недели) 
+Однако, если вы используете свой формат даты и в этом формате задействованы символические переменные \cs{cuDOW} (день недели)
 или \cs{cuYEARAM} (год от сотворения мира), то значения этих переменных будут вычислены исходя из заданной даты --- и дата интерпретируется
 как дата по григорианскому календарю (<<новому стилю>>). В этом случае, невозможные даты будут нормализованы методом экстраполяции. Например, 32 апреля
 будет интерпретировано как 2 мая для целей определения дня недели и года от сотворения мира.
@@ -368,7 +368,7 @@ Example:
 \begin{tabular}{l}
 \verb+\cuDefineDateFormat{long}{%+\\
 \verb+  \cuDayName{\cuDOW},+\\
-\verb+  \cuNum{\cuDAY}+_гѡ\verb+~%+\\
+\verb+  \cuNum{\cuDAY}\textunderscore +гѡ\verb+~%+\\
 \verb+  \cuMonthName{\cuMONTH},~%+\\
 \verb+  +лѣ́та ѿ сотворе́нїѧ мі́ра\verb+~%+\\
 \verb+  \cuNum{\cuYEARAM}%+\\
@@ -395,8 +395,8 @@ The following symbolic names can be used when formatting the date:
 \item \cs{cuMONTH} --- the month part of a date (a number from 1 to 12, with January set to 1)
 \item \cs{cuDAY} --- the day of the month
 \item \cs{cuDOW}\footnotemark[1] --- the day of the week (number from 0 to 6, where 0 means ``Sunday'')
-\footnotetext[1]{If your format uses this value, make sure that you format the date with the correct macro: 
-    you must use \cs{cuDate} for dates on the Gregorian calendar and 
+\footnotetext[1]{If your format uses this value, make sure that you format the date with the correct macro:
+    you must use \cs{cuDate} for dates on the Gregorian calendar and
     \cs{cuDateJulian} for dates on the Julian calendar.}
 \footnotetext[2]{See \url{https://en.wikipedia.org/wiki/Indiction}.}
 \item \cs{cuINDICTION} --- the indiction\footnotemark[2] (a number from 1 to 15)
@@ -414,7 +414,7 @@ The following symbolic names can be used when formatting the date:
 \item \cs{cuDOW}\footnotemark[1] --- день недели (число от 0 to 6, где 0 означает ``воскресенье'')
 \item \cs{cuINDICTION} --- индикт\footnotemark[2] (число от 1 до 15)
 \footnotetext[1]{Если ваш формат
-    пользуется этим значением, вы должны форматировать дату правильной макрокомандой: \cs{cuDate} 
+    пользуется этим значением, вы должны форматировать дату правильной макрокомандой: \cs{cuDate}
     для дат по григорианскому календарю и \cs{cuDateJulian} для дат по юлианскому календарю.}
 \footnotetext[2]{См.~\url{https://ru.wikipedia.org/wiki/\%D0\%98\%D0\%BD\%D0\%B4\%D0\%B8\%D0\%BA\%D1\%82}}
 \end{itemize}
@@ -564,8 +564,8 @@ editor to just automatically place a \cs{cuKinovar} command before every paragra
 \begin{churchslavonic}
 \begin{tabular}[]{ | l | l | }
 \hline
-\verb+\cuKinovar+ Пои́мъ гдⷭ҇ви пѣ́снь но́вꙋю & 
-\cuKinovar Пои́мъ гдⷭ҇ви пѣ́снь но́вꙋю \\ 
+\verb+\cuKinovar+ Пои́мъ гдⷭ҇ви пѣ́снь но́вꙋю &
+\cuKinovar Пои́мъ гдⷭ҇ви пѣ́снь но́вꙋю \\
 \verb+\cuKinovar+ Ꙗ҆́кѡ тꙋ́ча на тро́скотъ & \cuKinovar Ꙗ҆́кѡ тꙋ́ча на тро́скотъ \\
 \hline
 \end{tabular}
@@ -634,9 +634,9 @@ Will result in:
 \let\hKv=\cuKinovar
 \parbox{0.75\textwidth}{%
   \textwidth=0.75\textwidth
-  \hMn{в҃}\hKv Бл҃гословѝ дꙋшѐ моѧ̀ гдⷭ҇а и҆ не забыва́й всѣ́хъ  воздаѧ́нїй є҆гѡ̀. 
+  \hMn{в҃}\hKv Бл҃гословѝ дꙋшѐ моѧ̀ гдⷭ҇а и҆ не забыва́й всѣ́хъ  воздаѧ́нїй є҆гѡ̀.
   \hMn{а҃}\hKv Ѡ҆чища́ющаго всѧ̑ беззакѡ́нїѧ твоѧ̑, и҆сцѣлѧ́ющаго  всѧ̑ недꙋ́ги твоѧ̑:
-  \hMn{в҃}\hKv И҆збавлѧ́ющаго ѿ и҆стлѣ́нїѧ  живо́тъ тво́й, вѣнча́ющаго тѧ̀ млⷭ҇тїю и҆ щедро́тами: 
+  \hMn{в҃}\hKv И҆збавлѧ́ющаго ѿ и҆стлѣ́нїѧ  живо́тъ тво́й, вѣнча́ющаго тѧ̀ млⷭ҇тїю и҆ щедро́тами:
   \hMn{а҃}\hKv И҆сполнѧ́ющаго во бл҃ги́хъ жела́нїе твоѐ, ѡ҆бнови́тсѧ  ꙗ҆́кѡ ѻ҆́рлѧ ю҆́ность твоѧ̀.
 }
 \end{churchslavonic}
@@ -670,7 +670,7 @@ document like this:
 \begin{RU}
 Шрифт и цвет пометы можно изменить, переопределив команду \cs{cuMarginMarkText}.
 Например, если Вы хотите чтобы все пометы печатались красным цветом, то достаточно поместить
-в преамбулу вашего документа следующее определение: 
+в преамбулу вашего документа следующее определение:
 \end{RU}
 \begin{verbatim}
 \def\cuMarginMarkText#1{\cuKinovar{#1}}
@@ -747,9 +747,9 @@ you can create drop capitals like this:
 \parbox{0.75\textwidth}{%
 \textwidth=0.75\textwidth
 
-\cuLettrine 
-И҆́же дх҃а си́ла въ не́мощи соверша́етсѧ, ꙗ҆́коже пи́сано є҆́сть, и҆ вѣ́рꙋемъ: въ не́мощи же не тѣлесѐ то́чїю, но ᲂу҆́бѡ и҆ сло́ва, 
-и҆ премꙋ́дрости на ѧ҆зы́цѣ лежа́ща. И҆ сѐ ꙗ҆́вѣ ѿ мно́гихъ ᲂу҆́бѡ и҆ны́хъ, па́че же ѿ и҆́же ѡ҆ вели́комъ бг҃осло́вѣ, и҆ бра́тѣ хрⷭ҇то́вѣ, 
+\cuLettrine
+И҆́же дх҃а си́ла въ не́мощи соверша́етсѧ, ꙗ҆́коже пи́сано є҆́сть, и҆ вѣ́рꙋемъ: въ не́мощи же не тѣлесѐ то́чїю, но ᲂу҆́бѡ и҆ сло́ва,
+и҆ премꙋ́дрости на ѧ҆зы́цѣ лежа́ща. И҆ сѐ ꙗ҆́вѣ ѿ мно́гихъ ᲂу҆́бѡ и҆ны́хъ, па́че же ѿ и҆́же ѡ҆ вели́комъ бг҃осло́вѣ, и҆ бра́тѣ хрⷭ҇то́вѣ,
 благода́тїю зри́мѣмъ.
 }%
 \end{churchslavonic}


### PR DESCRIPTION
Please, review.

This is a workaround. Apparently, even though we re-defined underscore in the text mode, its safer to use `\texunderscore` control sequence in macros and date templates.