### PR TITLE
attempt to fix tilda as empty kruk/syl

### DIFF
--- a/cu-kruk.sty
+++ b/cu-kruk.sty
@@ -27,12 +27,17 @@
   \egroup
 }%
 \def\cu@@Kruk#1#2{{%
+  \edef\cu@tmp{\csname \detokenize{#2}cu@@@\endcsname}%
   \setbox1=\hbox{{\cuKrukFont#1}}%
   \dimen0=\ht1\advance\dimen0 by \cuKrukTopMargin\ht1=\dimen0%
   \if\relax\detokenize{#2}\relax
     \setbox2=\hbox{\vrule height \cuKrukSylRuleHeight width \wd1}%
   \else
-    \setbox2=\hbox{#2}%
+    \ifx\cu@tmp\cu@Tilda
+      \setbox2=\hbox{\vrule height \cuKrukSylRuleHeight width \wd1}%
+    \else
+      \setbox2=\hbox{#2}%
+    \fi
   \fi
   \ifdim\wd1>\wd2%
     \setbox2=\hbox to \wd1{\hss\box2\hss}%

--- a/cu-kruk.sty
+++ b/cu-kruk.sty
@@ -74,7 +74,6 @@
 \edef\cu@tmp{\csname \detokenize{#1}cu@@@\endcsname}%
 \ifx\cu@tmp\cu@Tilda
   \expandafter\edef\csname cu@@\thecu@KrukPos\endcsname{}%
-  \message{KRUK-tilda}%
 \else
   \expandafter\def\csname cu@@\thecu@KrukPos\endcsname{#1}%
 \fi
@@ -108,7 +107,6 @@
 \edef\cu@tmp{\csname \detokenize{#1}cu@@@\endcsname}%
 \ifx\cu@tmp\cu@Tilda
   \expandafter\cuKruk\expandafter{\csname cu@@\thecu@SylPos\endcsname}{}%
-  \message{TILDA-syl}%
 \else
   \expandafter\cuKruk\expandafter{\csname cu@@\thecu@SylPos\endcsname}{#1}%
 \fi

--- a/cu-kruk.sty
+++ b/cu-kruk.sty
@@ -71,8 +71,10 @@
 }%
 %
 \def\cu@KrukAction#1{%
-\expandafter\expandafter\expandafter\ifx\expandafter\csname \detokenize{#1}cu@@@\endcsname\cu@Tilda
+\edef\cu@tmp{\csname \detokenize{#1}cu@@@\endcsname}%
+\ifx\cu@tmp\cu@Tilda
   \expandafter\edef\csname cu@@\thecu@KrukPos\endcsname{}%
+  \message{KRUK-tilda}%
 \else
   \expandafter\def\csname cu@@\thecu@KrukPos\endcsname{#1}%
 \fi
@@ -103,7 +105,13 @@
 \ifnum\thecu@SylPos>\thecu@KrukPos
   \errmessage{Too few kruk groups. Seen {\thecu@KrukPos} kruk groups and {\thecu@SylPos} text groups}%
 \fi
-\expandafter\cuKruk\expandafter{\csname cu@@\thecu@SylPos\endcsname}{#1}%
+\edef\cu@tmp{\csname \detokenize{#1}cu@@@\endcsname}%
+\ifx\cu@tmp\cu@Tilda
+  \expandafter\cuKruk\expandafter{\csname cu@@\thecu@SylPos\endcsname}{}%
+  \message{TILDA-syl}%
+\else
+  \expandafter\cuKruk\expandafter{\csname cu@@\thecu@SylPos\endcsname}{#1}%
+\fi
 \stepcounter{cu@SylPos}%
 }%
 %

--- a/cu-kruk.sty
+++ b/cu-kruk.sty
@@ -81,6 +81,7 @@
 }
 %
 \edef\cu@Tilda{\csname \detokenize{~}cu@@@\endcsname}%
+\edef\cu@Empty{\csname \detokenize{}cu@@@\endcsname}%
 %
 \def\cu@Text#1 #2\cu@EndText{%
 \if\relax\detokenize{#1}\relax\else
@@ -92,9 +93,7 @@
 }%
 %
 \def\cu@TextDash#1-#2\cu@EndText{%
-\if\relax\detokenize{#1}\relax\else
-  \cu@TextAction{#1}%
-\fi
+\cu@TextAction{#1}%
 \if\relax\detokenize{#2}\relax\else
   \cu@TextDash#2\cu@EndText
 \fi
@@ -105,10 +104,14 @@
   \errmessage{Too few kruk groups. Seen {\thecu@KrukPos} kruk groups and {\thecu@SylPos} text groups}%
 \fi
 \edef\cu@tmp{\csname \detokenize{#1}cu@@@\endcsname}%
-\ifx\cu@tmp\cu@Tilda
+\ifx\cu@tmp\cu@Empty
   \expandafter\cuKruk\expandafter{\csname cu@@\thecu@SylPos\endcsname}{}%
 \else
-  \expandafter\cuKruk\expandafter{\csname cu@@\thecu@SylPos\endcsname}{#1}%
+  \ifx\cu@tmp\cu@Tilda
+    \expandafter\cuKruk\expandafter{\csname cu@@\thecu@SylPos\endcsname}{}%
+  \else
+    \expandafter\cuKruk\expandafter{\csname cu@@\thecu@SylPos\endcsname}{#1}%
+  \fi
 \fi
 \stepcounter{cu@SylPos}%
 }%


### PR DESCRIPTION
Not pretty, but seem to work.

Problem was that `\cuKrukPara` supported tilda as an empty kruk (and even this was broken), but did not support tilda as empty syllable.

Fix makes sure that tilda symbol can be used in kruk section to mark empty kruk (corresponding syllable will have no kruk on top of it). And tilda symbol can be used in syllable section to denote an empty syllable (underscore line will be drawn under the kruk).

Using tilda text with tilda kruk does not make sense and probably will not work (untested).

Note that this PR is on top of the `add-cu-kruk` PR, so merge it in first.