### PR TITLE
added option to automatically color pometa, or not; hyphenation char

### DIFF
--- a/churchslavonic.sty
+++ b/churchslavonic.sty
@@ -3,11 +3,18 @@
 %
 \ProvidesPackage{churchslavonic}[2017/02/05 v0.2.2 Typesetting in Church Slavonic]
 
+\DeclareOption{autocolormarks}{
+	\PassOptionsToPackage{\CurrentOption}{cu-kruk}
+}
+\DeclareOption{noautocolormarks}{
+	\PassOptionsToPackage{\CurrentOption}{cu-kruk}
+}
 \DeclareOption*{
 	\PassOptionsToPackage{\CurrentOption}{cu-kinovar}
 }
 \ProcessOptions\relax
 
+\RequirePackage{ifluatex}
 \RequirePackage{cu-num}
 \RequirePackage{cu-calendar}
 \RequirePackage{cu-util}
@@ -21,6 +28,22 @@
 \global\protected\def_{\ifmmode\cu@oldunderscore\else\textunderscore\discretionary{}{}{}\fi}%
 }%
 \AtBeginDocument{\catcode`\_\active}%
+
+\ifluatex
+\AtBeginDocument{\cu@set@hyphenchar@lualatex}
+\else
+\AtBeginDocument{\cu@set@hyphenchar@xelatex}
+\fi
+
+\def\cu@set@hyphenchar@lualatex{
+  \@ifpackageloaded{polyglossia}{%
+    \textchurchslavonic{\prehyphenchar=`\_}%
+  }{%
+  }%
+}%
+
+\def\cu@set@hyphenchar@xelatex{
+}%
 
 % suppress variable distance between lines
 \lineskiplimit -1ex

--- a/cu-kinovar.sty
+++ b/cu-kinovar.sty
@@ -3,6 +3,10 @@
 \RequirePackage{cu-util}
 \RequirePackage{etoolbox}
 \RequirePackage{xcolor}
+\RequirePackage{ifluatex}
+\ifluatex
+  \RequirePackage{luacolor}
+\fi
 
 %% 'color' option (default)
 \def\cu@kinovar{\relax}

--- a/cu-kruk.sty
+++ b/cu-kruk.sty
@@ -1,7 +1,26 @@
 \NeedsTeXFormat{LaTeX2e}%
 \RequirePackage{keyval}%
+\RequirePackage{ifluatex}%
 \ProvidesPackage{cu-kruk}[2018/03/01 v0.1 support for kruk music notations]%
 %
+%% 'autocolormarks' and noautocolormarks options
+\newif\ifcu@autocolormarks
+\ifluatex
+  \cu@autocolormarkstrue
+\else
+  \cu@autocolormarksfalse
+\fi
+
+\DeclareOption{autocolormarks}{
+  \cu@autocolormarkstrue
+  \ifluatex\relax\else\message{WARNING: autocolormarks option may not work correctly with this TeX engine. See documentation for more details.}\fi
+}
+\DeclareOption{noautocolormarks}{
+  \cu@autocolormarksfalse
+}
+
+\ProcessOptions\relax
+
 \let\cuKrukFont\relax %% to be defined by the user
 %
 \newlength{\cuKrukSylSpace}  %% spacing around kruk syllable
@@ -122,6 +141,7 @@
 }%
 %
 % Automatic coloring of kruk marks (pometa)
+\ifcu@autocolormarks
 \catcode`\active\def{\cuKinovar{\detokenize{}}}%
 \catcode`\active\def{\cuKinovar{\detokenize{}}}%
 \catcode`\active\def{\cuKinovar{\detokenize{}}}%
@@ -186,5 +206,6 @@
 \catcode`\active\def{\cuKinovar{\detokenize{}}}%
 \catcode`\active\def{\cuKinovar{\detokenize{}}}%
 \catcode`\active\def{\cuKinovar{\detokenize{}}}%
+\fi
 %
 \endinput%


### PR DESCRIPTION
Options `autocolormarks` and `noautocolormarks` added.

If LuaLaTeX engine is detected, defaults to `autocolormarks`, else `noautocolormarks`.

If user forces `autocolormarks` option, but engine is not LuaLaTeX, a warning is issued.

When LuaLaTeX engine is detected, automatically loads package `luacolor`.

Experimental: if LuaLaTeX engine is detected, sets hyphenation character to be _ (only for churchslavonic text spans). No control which character is used for hyphenation of churchslavonic yet.